### PR TITLE
add modern normalize

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,9 +8,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cabin&family=Roboto&family=Sarabun:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="node_modules/modern-normalize/modern-normalize.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/modern-normalize/3.0.1/modern-normalize.min.css" 
+    integrity="sha512-q6WgHqiHlKyOqslT/lgBgodhd03Wp4BEqKeW6nNtlOY4quzyG3VoQKFrieaCeSnuVseNKRGpGeDU3qPmabCANg==" 
+    crossorigin="anonymous" 
+    referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="./css/styles.css" />
-
+   
 
   </head>
   <body>


### PR DESCRIPTION
Я додала в файл index.html посилання на modern-normalize, як ми робили в домашках. В темплейті там стояло посилання на node-modules, але файлів там не було, тому не спрацьовув нормалізатор. Я це помітила, бо у самого body був margin: 8px, який міняв розміщення всього. Після підключення modern-normalize цей маржин обнулився і не заважає. 